### PR TITLE
 ZK 3.5 part 2 - Adding reconfig and incremental reconfig apis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ script:
 matrix:
   allow_failures:
     - go: tip
-    - env: zk_version=3.5.4-beta
   fast_finish: true
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,14 @@ branches:
     - dev
 
 before_install:
-  - make travis ZK_VERSION=${zk_version}
+  - make setup ZK_VERSION=${zk_version}
 
 before_script:
-  - go vet ./...
-  - go fmt ./...
+  - make lint
 
 script:
   - jdk_switcher use oraclejdk9
-  - go build ./...
-  - make test
+  - make
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ sudo: false
 branches:
   only:
     - master
-    - dev
 
 before_install:
   - make setup ZK_VERSION=${zk_version}

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,6 @@ build:
 
 .PHONY: test
 test: build
-	go test -timeout 300s -v -race -covermode atomic -coverprofile=profile.cov $(PACKAGES)
+	go test -timeout 500s -v -race -covermode atomic -coverprofile=profile.cov $(PACKAGES)
 	# ignore if we fail to publish coverage
 	-goveralls -coverprofile=profile.cov -service=travis-ci

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ ZK_VERSION ?= 3.4.12
 ZK = zookeeper-$(ZK_VERSION)
 ZK_URL = "https://archive.apache.org/dist/zookeeper/$(ZK)/$(ZK).tar.gz"
 
+PACKAGES := $(shell go list ./... | grep -v examples)
+
+.DEFAULT_GOAL := test
+
 $(ZK):
 	wget $(ZK_URL)
 	tar -zxf $(ZK).tar.gz
@@ -11,19 +15,25 @@ $(ZK):
 	# in the test code. this allows backward compatable testing.
 	ln -s $(ZK) zookeeper
 
-
-.PHONY: install-test-deps
-install-test-deps:
+.PHONY: install-covertools
+install-covertools:
 	go get github.com/mattn/goveralls
 	go get golang.org/x/tools/cmd/cover
 
-.PHONY: travis
-travis: $(ZK) install-test-deps
+.PHONY: setup
+setup: $(ZK) install-covertools
+
+.PHONY: lint
+lint:
+	go fmt ./...
+	go vet ./...
+
+.PHONY: build
+build:
+	go build ./...
 
 .PHONY: test
-test:
-	go test -timeout 300s -v ./...
-	go test -timeout 400s -v -i -race ./...
-	go test -timeout 400s -v -race -covermode atomic -coverprofile=profile.cov ./zk
+test: build
+	go test -timeout 300s -v -race -covermode atomic -coverprofile=profile.cov $(PACKAGES)
 	# ignore if we fail to publish coverage
 	-goveralls -coverprofile=profile.cov -service=travis-ci

--- a/zk/cluster_test.go
+++ b/zk/cluster_test.go
@@ -22,12 +22,12 @@ func TestBasicCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ts.Stop()
-	zk1, err := ts.Connect(0)
+	zk1, _, err := ts.Connect(0)
 	if err != nil {
 		t.Fatalf("Connect returned error: %+v", err)
 	}
 	defer zk1.Close()
-	zk2, err := ts.Connect(1)
+	zk2, _, err := ts.Connect(1)
 	if err != nil {
 		t.Fatalf("Connect returned error: %+v", err)
 	}
@@ -191,7 +191,7 @@ func TestWaitForClose(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ts.Stop()
-	zk, err := ts.Connect(0)
+	zk, _, err := ts.Connect(0)
 	if err != nil {
 		t.Fatalf("Connect returned error: %+v", err)
 	}

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -409,13 +409,11 @@ func (c *Conn) resendZkAuth(reauthReadyChan chan struct{}) {
 	defer close(reauthReadyChan)
 
 	if c.logInfo {
-		c.logger.Printf("Re-submitting `%d` credentials after reconnect",
-			len(c.creds))
+		c.logger.Printf("re-submitting `%d` credentials after reconnect", len(c.creds))
 	}
 
 	for _, cred := range c.creds {
 		if shouldCancel() {
-			c.logger.Printf("Cancel rer-submitting credentials")
 			return
 		}
 		resChan, err := c.sendRequest(
@@ -428,7 +426,7 @@ func (c *Conn) resendZkAuth(reauthReadyChan chan struct{}) {
 			nil)
 
 		if err != nil {
-			c.logger.Printf("Call to sendRequest failed during credential resubmit: %s", err)
+			c.logger.Printf("call to sendRequest failed during credential resubmit: %s", err)
 			// FIXME(prozlach): lets ignore errors for now
 			continue
 		}
@@ -437,14 +435,14 @@ func (c *Conn) resendZkAuth(reauthReadyChan chan struct{}) {
 		select {
 		case res = <-resChan:
 		case <-c.closeChan:
-			c.logger.Printf("Recv closed, cancel re-submitting credentials")
+			c.logger.Printf("recv closed, cancel re-submitting credentials")
 			return
 		case <-c.shouldQuit:
-			c.logger.Printf("Should quit, cancel re-submitting credentials")
+			c.logger.Printf("should quit, cancel re-submitting credentials")
 			return
 		}
 		if res.err != nil {
-			c.logger.Printf("Credential re-submit failed: %s", res.err)
+			c.logger.Printf("credential re-submit failed: %s", res.err)
 			// FIXME(prozlach): lets ignore errors for now
 			continue
 		}
@@ -486,14 +484,14 @@ func (c *Conn) loop() {
 		err := c.authenticate()
 		switch {
 		case err == ErrSessionExpired:
-			c.logger.Printf("Authentication failed: %s", err)
+			c.logger.Printf("authentication failed: %s", err)
 			c.invalidateWatches(err)
 		case err != nil && c.conn != nil:
-			c.logger.Printf("Authentication failed: %s", err)
+			c.logger.Printf("authentication failed: %s", err)
 			c.conn.Close()
 		case err == nil:
 			if c.logInfo {
-				c.logger.Printf("Authenticated: id=%d, timeout=%d", c.SessionID(), c.sessionTimeoutMs)
+				c.logger.Printf("authenticated: id=%d, timeout=%d", c.SessionID(), c.sessionTimeoutMs)
 			}
 			c.hostProvider.Connected()        // mark success
 			c.closeChan = make(chan struct{}) // channel to tell send loop stop
@@ -508,7 +506,7 @@ func (c *Conn) loop() {
 				}
 				err := c.sendLoop()
 				if err != nil || c.logInfo {
-					c.logger.Printf("Send loop terminated: err=%v", err)
+					c.logger.Printf("send loop terminated: err=%v", err)
 				}
 				c.conn.Close() // causes recv loop to EOF/exit
 				wg.Done()
@@ -523,7 +521,7 @@ func (c *Conn) loop() {
 					err = c.recvLoop(c.conn)
 				}
 				if err != io.EOF || c.logInfo {
-					c.logger.Printf("Recv loop terminated: err=%v", err)
+					c.logger.Printf("recv loop terminated: err=%v", err)
 				}
 				if err == nil {
 					panic("zk: recvLoop should never return nil error")
@@ -823,10 +821,12 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 	buf := make([]byte, sz)
 	for {
 		// package length
-		conn.SetReadDeadline(time.Now().Add(c.recvTimeout))
+		if err := conn.SetReadDeadline(time.Now().Add(c.recvTimeout)); err != nil {
+			c.logger.Printf("failed to set connection deadline: %v", err)
+		}
 		_, err := io.ReadFull(conn, buf[:4])
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to read from connection: %v", err)
 		}
 
 		blen := int(binary.BigEndian.Uint32(buf[:4]))
@@ -1218,6 +1218,40 @@ func (c *Conn) Multi(ops ...interface{}) ([]MultiResponse, error) {
 		mr[i] = MultiResponse{Stat: op.Stat, String: op.String, Error: op.Err.toError()}
 	}
 	return mr, err
+}
+
+// IncrementalReconfig is the zookeeper reconfiguration api that allows adding and removing servers
+// by lists of members.
+// Return the new configuration stats.
+// TODO: expose and return the config znode itself like the Java client does.
+func (c *Conn) IncrementalReconfig(joining, leaving []string, version int64) (*Stat, error) {
+	// TODO: validate the shape of the member string to give early feedback.
+	request := &reconfigRequest{
+		JoiningServers: []byte(strings.Join(joining, ",")),
+		LeavingServers: []byte(strings.Join(leaving, ",")),
+		CurConfigId:    version,
+	}
+
+	return c.internalReconfig(request)
+}
+
+// Reconfig is the non-incremental update functionality for Zookeeper where the list preovided
+// is the entire new member list.
+// the optional version allows for conditional reconfigurations, -1 ignores the condition.
+// TODO: expose and return the config znode itself like the Java client does.
+func (c *Conn) Reconfig(members []string, version int64) (*Stat, error) {
+	request := &reconfigRequest{
+		NewMembers:  []byte(strings.Join(members, ",")),
+		CurConfigId: version,
+	}
+
+	return c.internalReconfig(request)
+}
+
+func (c *Conn) internalReconfig(request *reconfigRequest) (*Stat, error) {
+	response := &reconfigReponse{}
+	_, err := c.request(opReconfig, request, response, nil)
+	return &response.Stat, err
 }
 
 // Server returns the current or last-connected server name.

--- a/zk/server_java.go
+++ b/zk/server_java.go
@@ -128,13 +128,14 @@ func (sc ServerConfig) Marshall(w io.Writer) error {
 	// TODO: allow setting this
 	fmt.Fprintln(w, "reconfigEnabled=true")
 	fmt.Fprintln(w, "4lw.commands.whitelist=*")
-	fmt.Fprintln(w, "standaloneEnabled=false")
 
 	if len(sc.Servers) < 2 {
 		// if we dont have more than 2 servers we just dont specify server list to start in standalone mode
 		// see https://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_InstallingSingleMode for more details.
 		return nil
 	}
+	// if we then have more than one server force it to be distributed
+	fmt.Fprintln(w, "standaloneEnabled=false")
 
 	for _, srv := range sc.Servers {
 		if srv.PeerPort <= 0 {

--- a/zk/server_java.go
+++ b/zk/server_java.go
@@ -119,16 +119,21 @@ func (sc ServerConfig) Marshall(w io.Writer) error {
 		fmt.Fprintf(w, "autopurge.snapRetainCount=%d\n", sc.AutoPurgeSnapRetainCount)
 		fmt.Fprintf(w, "autopurge.purgeInterval=%d\n", sc.AutoPurgePurgeInterval)
 	}
-	if len(sc.Servers) > 0 {
-		for _, srv := range sc.Servers {
-			if srv.PeerPort <= 0 {
-				srv.PeerPort = DefaultPeerPort
-			}
-			if srv.LeaderElectionPort <= 0 {
-				srv.LeaderElectionPort = DefaultLeaderElectionPort
-			}
-			fmt.Fprintf(w, "server.%d=%s:%d:%d\n", srv.ID, srv.Host, srv.PeerPort, srv.LeaderElectionPort)
+
+	if len(sc.Servers) < 2 {
+		// if we dont have more than 2 servers we just dont specify server list to start in standalone mode
+		// see https://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_InstallingSingleMode for more details.
+		return nil
+	}
+
+	for _, srv := range sc.Servers {
+		if srv.PeerPort <= 0 {
+			srv.PeerPort = DefaultPeerPort
 		}
+		if srv.LeaderElectionPort <= 0 {
+			srv.LeaderElectionPort = DefaultLeaderElectionPort
+		}
+		fmt.Fprintf(w, "server.%d=%s:%d:%d\n", srv.ID, srv.Host, srv.PeerPort, srv.LeaderElectionPort)
 	}
 	return nil
 }

--- a/zk/structs.go
+++ b/zk/structs.go
@@ -277,6 +277,18 @@ type multiResponse struct {
 	DoneHeader multiHeader
 }
 
+// zk version 3.5 reconfig API
+type reconfigRequest struct {
+	JoiningServers []byte
+	LeavingServers []byte
+	NewMembers     []byte
+	// curConfigId version of the current configuration
+	// optional - causes reconfiguration to return an error if configuration is no longer current
+	CurConfigId int64
+}
+
+type reconfigReponse getDataResponse
+
 func (r *multiRequest) Encode(buf []byte) (int, error) {
 	total := 0
 	for _, op := range r.Ops {
@@ -604,6 +616,8 @@ func requestStructForOp(op int32) interface{} {
 		return &CheckVersionRequest{}
 	case opMulti:
 		return &multiRequest{}
+	case opReconfig:
+		return &reconfigRequest{}
 	}
 	return nil
 }

--- a/zk/structs_test.go
+++ b/zk/structs_test.go
@@ -15,6 +15,7 @@ func TestEncodeDecodePacket(t *testing.T) {
 	encodeDecodeTest(t, &pathWatchRequest{"path", true})
 	encodeDecodeTest(t, &pathWatchRequest{"path", false})
 	encodeDecodeTest(t, &CheckVersionRequest{"/", -1})
+	encodeDecodeTest(t, &reconfigRequest{nil, nil, nil, -1})
 	encodeDecodeTest(t, &multiRequest{Ops: []multiRequestOp{{multiHeader{opCheck, false, -1}, &CheckVersionRequest{"/", -1}}}})
 }
 

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -176,15 +176,23 @@ func TestIncrementalReconfig(t *testing.T) {
 
 	// remove node 3.
 	_, err = zk.IncrementalReconfig(nil, []string{"3"}, -1)
-	requireNoError(t, err, "failed to remove node from cluster")
+	if err != nil && err == ErrConnectionClosed {
+		t.Log("conneciton closed is fine since the cluster re-elects and we dont reconnect")
+	} else {
+		requireNoError(t, err, "failed to remove node from cluster")
+	}
 
 	// add node a new 4th node
 	server := fmt.Sprintf("server.%d=%s:%d:%d;%d", testSrvConfig.ID, testSrvConfig.Host, testSrvConfig.PeerPort, testSrvConfig.LeaderElectionPort, cfg.ClientPort)
 	_, err = zk.IncrementalReconfig([]string{server}, nil, -1)
-	requireNoError(t, err, "failed to add new server to cluster")
+	if err != nil && err == ErrConnectionClosed {
+		t.Log("conneciton closed is fine since the cluster re-elects and we dont reconnect")
+	} else {
+		requireNoError(t, err, "failed to add new server to cluster")
+	}
 }
 
-func TestReconfg(t *testing.T) {
+func TestReconfig(t *testing.T) {
 	if val, ok := os.LookupEnv("zk_version"); ok {
 		if !strings.HasPrefix(val, "3.5") {
 			t.Skip("running with zookeeper that does not support this api")

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -98,6 +98,13 @@ func TestCreate(t *testing.T) {
 }
 
 func TestIncrementalReconfig(t *testing.T) {
+	if val, ok := os.LookupEnv("zk_version"); ok {
+		if !strings.HasPrefix(val, "3.5") {
+			t.Skip("running with zookeeper that does not support this api")
+		}
+	} else {
+		t.Skip("did not detect zk_version from env. skipping reconfig test")
+	}
 	ts, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
 	requireNoError(t, err, "failed to setup test cluster")
 	defer ts.Stop()
@@ -178,6 +185,14 @@ func TestIncrementalReconfig(t *testing.T) {
 }
 
 func TestReconfg(t *testing.T) {
+	if val, ok := os.LookupEnv("zk_version"); ok {
+		if !strings.HasPrefix(val, "3.5") {
+			t.Skip("running with zookeeper that does not support this api")
+		}
+	} else {
+		t.Skip("did not detect zk_version from env. skipping reconfig test")
+	}
+
 	// This test enures we can do an non-incremental reconfig
 	ts, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
 	requireNoError(t, err, "failed to setup test cluster")

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -1,11 +1,15 @@
 package zk
 
 import (
-	"crypto/rand"
+	"context"
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"math/rand"
 	"net"
+	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"sort"
@@ -91,6 +95,130 @@ func TestCreate(t *testing.T) {
 	} else if len(data) < 4 {
 		t.Fatal("Get returned wrong size data")
 	}
+}
+
+func TestIncrementalReconfig(t *testing.T) {
+	ts, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
+	requireNoError(t, err, "failed to setup test cluster")
+	defer ts.Stop()
+
+	// start and add a new server.
+	tmpPath, err := ioutil.TempDir("", "gozk")
+	requireNoError(t, err, "failed to create tmp dir for test server setup")
+	defer os.RemoveAll(tmpPath)
+
+	startPort := int(rand.Int31n(6000) + 10000)
+
+	srvPath := filepath.Join(tmpPath, fmt.Sprintf("srv4"))
+	if err := os.Mkdir(srvPath, 0700); err != nil {
+		requireNoError(t, err, "failed to make server path")
+	}
+	testSrvConfig := ServerConfigServer{
+		ID:                 4,
+		Host:               "127.0.0.1",
+		PeerPort:           startPort + 1,
+		LeaderElectionPort: startPort + 2,
+	}
+	cfg := ServerConfig{
+		ClientPort: startPort,
+		DataDir:    srvPath,
+		Servers:    []ServerConfigServer{testSrvConfig},
+	}
+
+	// TODO: clean all this server creating up to a better helper method
+	cfgPath := filepath.Join(srvPath, _testConfigName)
+	fi, err := os.Create(cfgPath)
+	requireNoError(t, err)
+
+	requireNoError(t, cfg.Marshall(fi))
+	fi.Close()
+
+	fi, err = os.Create(filepath.Join(srvPath, _testMyIDFileName))
+	requireNoError(t, err)
+
+	_, err = fmt.Fprintln(fi, "4")
+	fi.Close()
+	requireNoError(t, err)
+
+	testServer, err := NewIntegrationTestServer(t, cfgPath, nil, nil)
+	requireNoError(t, err)
+	requireNoError(t, testServer.Start())
+	defer testServer.Stop()
+
+	zk, events, err := ts.ConnectAll()
+	requireNoError(t, err, "failed to connect to cluster")
+	defer zk.Close()
+
+	err = zk.AddAuth("digest", []byte("super:test"))
+	requireNoError(t, err, "failed to auth to cluster")
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err = waitForSession(waitCtx, events)
+	requireNoError(t, err, "failed to wail for session")
+
+	_, _, err = zk.Get("/zookeeper/config")
+	if err != nil {
+		t.Fatalf("get config returned error: %+v", err)
+	}
+
+	// initially should be 1<<32, which is 0x100000000. This is the zxid
+	// of the first NEWLEADER message, used as the inital version
+	// reflect.DeepEqual(bytes.Split(data, []byte("\n")), []byte("version=100000000"))
+
+	// remove node 3.
+	_, err = zk.IncrementalReconfig(nil, []string{"3"}, -1)
+	requireNoError(t, err, "failed to remove node from cluster")
+
+	// add node a new 4th node
+	server := fmt.Sprintf("server.%d=%s:%d:%d;%d", testSrvConfig.ID, testSrvConfig.Host, testSrvConfig.PeerPort, testSrvConfig.LeaderElectionPort, cfg.ClientPort)
+	_, err = zk.IncrementalReconfig([]string{server}, nil, -1)
+	requireNoError(t, err, "failed to add new server to cluster")
+}
+
+func TestReconfg(t *testing.T) {
+	// This test enures we can do an non-incremental reconfig
+	ts, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
+	requireNoError(t, err, "failed to setup test cluster")
+	defer ts.Stop()
+
+	zk, events, err := ts.ConnectAll()
+	requireNoError(t, err, "failed to connect to cluster")
+	defer zk.Close()
+
+	err = zk.AddAuth("digest", []byte("super:test"))
+	requireNoError(t, err, "failed to auth to cluster")
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err = waitForSession(waitCtx, events)
+	requireNoError(t, err, "failed to wail for session")
+
+	_, _, err = zk.Get("/zookeeper/config")
+	if err != nil {
+		t.Fatalf("get config returned error: %+v", err)
+	}
+
+	// essentially remove the first node
+	var s []string
+	for _, host := range ts.Config.Servers[1:] {
+		s = append(s, fmt.Sprintf("server.%d=%s:%d:%d;%d\n", host.ID, host.Host, host.PeerPort, host.LeaderElectionPort, ts.Config.ClientPort))
+	}
+
+	_, err = zk.Reconfig(s, -1)
+	requireNoError(t, err, "failed to reconfig cluster")
+
+	// reconfig to all the hosts again
+	s = []string{}
+	for _, host := range ts.Config.Servers {
+		s = append(s, fmt.Sprintf("server.%d=%s:%d:%d;%d\n", host.ID, host.Host, host.PeerPort, host.LeaderElectionPort, ts.Config.ClientPort))
+	}
+
+	_, err = zk.Reconfig(s, -1)
+	requireNoError(t, err, "failed to reconfig cluster")
+
 }
 
 func TestMulti(t *testing.T) {
@@ -725,64 +853,6 @@ func TestSlowServer(t *testing.T) {
 	}
 }
 
-func startSlowProxy(t *testing.T, up, down Rate, upstream string, adj func(ln *Listener)) (string, chan bool, error) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return "", nil, err
-	}
-	tln := &Listener{
-		Listener: ln,
-		Up:       up,
-		Down:     down,
-	}
-	stopCh := make(chan bool)
-	go func() {
-		<-stopCh
-		tln.Close()
-	}()
-	go func() {
-		for {
-			cn, err := tln.Accept()
-			if err != nil {
-				if !strings.Contains(err.Error(), "use of closed network connection") {
-					t.Fatalf("Accept failed: %s", err.Error())
-				}
-				return
-			}
-			if adj != nil {
-				adj(tln)
-			}
-			go func(cn net.Conn) {
-				defer cn.Close()
-				upcn, err := net.Dial("tcp", upstream)
-				if err != nil {
-					t.Log(err)
-					return
-				}
-				// This will leave hanging goroutines util stopCh is closed
-				// but it doesn't matter in the context of running tests.
-				go func() {
-					<-stopCh
-					upcn.Close()
-				}()
-				go func() {
-					if _, err := io.Copy(upcn, cn); err != nil {
-						if !strings.Contains(err.Error(), "use of closed network connection") {
-							// log.Printf("Upstream write failed: %s", err.Error())
-						}
-					}
-				}()
-				if _, err := io.Copy(cn, upcn); err != nil {
-					if !strings.Contains(err.Error(), "use of closed network connection") {
-						// log.Printf("Upstream read failed: %s", err.Error())
-					}
-				}
-			}(cn)
-		}
-	}()
-	return ln.Addr().String(), stopCh, nil
-}
-
 func TestMaxBufferSize(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
@@ -887,6 +957,64 @@ func TestMaxBufferSize(t *testing.T) {
 	if !reflect.DeepEqual(resultChildren, children) {
 		t.Fatalf("Children returned unexpected names; expecting %+v, got %+v", children, resultChildren)
 	}
+}
+
+func startSlowProxy(t *testing.T, up, down Rate, upstream string, adj func(ln *Listener)) (string, chan bool, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, err
+	}
+	tln := &Listener{
+		Listener: ln,
+		Up:       up,
+		Down:     down,
+	}
+	stopCh := make(chan bool)
+	go func() {
+		<-stopCh
+		tln.Close()
+	}()
+	go func() {
+		for {
+			cn, err := tln.Accept()
+			if err != nil {
+				if !strings.Contains(err.Error(), "use of closed network connection") {
+					t.Fatalf("Accept failed: %s", err.Error())
+				}
+				return
+			}
+			if adj != nil {
+				adj(tln)
+			}
+			go func(cn net.Conn) {
+				defer cn.Close()
+				upcn, err := net.Dial("tcp", upstream)
+				if err != nil {
+					t.Log(err)
+					return
+				}
+				// This will leave hanging goroutines util stopCh is closed
+				// but it doesn't matter in the context of running tests.
+				go func() {
+					<-stopCh
+					upcn.Close()
+				}()
+				go func() {
+					if _, err := io.Copy(upcn, cn); err != nil {
+						if !strings.Contains(err.Error(), "use of closed network connection") {
+							// log.Printf("Upstream write failed: %s", err.Error())
+						}
+					}
+				}()
+				if _, err := io.Copy(cn, upcn); err != nil {
+					if !strings.Contains(err.Error(), "use of closed network connection") {
+						// log.Printf("Upstream read failed: %s", err.Error())
+					}
+				}
+			}(cn)
+		}
+	}()
+	return ln.Addr().String(), stopCh, nil
 }
 
 func expectErr(t *testing.T, err error, expected error) {


### PR DESCRIPTION
* adds two new Public connection APIs `Reconfig` and `IncrementalReconfig` 
These two apis in the ZK server are mutually exclusive actions so in this client we break them up to ensure correct inputs for both cases.

* more test harness updates and we parse and skip these new tests if we are not using 3.5.. its a little rough but i think per this codebase bar its not as bad as other things. 