### PR TITLE
Cherrypick mesosphere fork changes on connection deadlock and Close once commits

### DIFF
--- a/zk/cluster_test.go
+++ b/zk/cluster_test.go
@@ -1,7 +1,6 @@
 package zk
 
 import (
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -18,7 +17,7 @@ func (lw logWriter) Write(b []byte) (int, error) {
 }
 
 func TestBasicCluster(t *testing.T) {
-	ts, err := StartTestCluster(t, 3, os.Stdout, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/zk/cluster_test.go
+++ b/zk/cluster_test.go
@@ -1,6 +1,7 @@
 package zk
 
 import (
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -17,7 +18,7 @@ func (lw logWriter) Write(b []byte) (int, error) {
 }
 
 func TestBasicCluster(t *testing.T) {
-	ts, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 3, os.Stdout, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -222,7 +222,8 @@ func Connect(servers []string, sessionTimeout time.Duration, options ...connOpti
 	}
 
 	conn.setTimeouts(int32(sessionTimeout / time.Millisecond))
-	// TODO: Connect should provide a way to specify a context for the connection
+	// TODO: this context should become to control the goroutines
+	// and connection itself, like use net.DialContext.
 	ctx := context.Background()
 
 	go func() {
@@ -1259,7 +1260,7 @@ func resendZkAuth(ctx context.Context, c *Conn) error {
 	}
 
 	for _, cred := range c.creds {
-		// return early befor attempting to send request.
+		// return early before attempting to send request.
 		if shouldCancel() {
 			return nil
 		}

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -1246,7 +1246,6 @@ func (c *Conn) Multi(ops ...interface{}) ([]MultiResponse, error) {
 // IncrementalReconfig is the zookeeper reconfiguration api that allows adding and removing servers
 // by lists of members.
 // Return the new configuration stats.
-// TODO: expose and return the config znode itself like the Java client does.
 func (c *Conn) IncrementalReconfig(joining, leaving []string, version int64) (*Stat, error) {
 	// TODO: validate the shape of the member string to give early feedback.
 	request := &reconfigRequest{
@@ -1261,7 +1260,6 @@ func (c *Conn) IncrementalReconfig(joining, leaving []string, version int64) (*S
 // Reconfig is the non-incremental update functionality for Zookeeper where the list preovided
 // is the entire new member list.
 // the optional version allows for conditional reconfigurations, -1 ignores the condition.
-// TODO: expose and return the config znode itself like the Java client does.
 func (c *Conn) Reconfig(members []string, version int64) (*Stat, error) {
 	request := &reconfigRequest{
 		NewMembers:  []byte(strings.Join(members, ",")),

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -1244,8 +1244,11 @@ func (c *Conn) Multi(ops ...interface{}) ([]MultiResponse, error) {
 }
 
 // IncrementalReconfig is the zookeeper reconfiguration api that allows adding and removing servers
-// by lists of members.
-// Return the new configuration stats.
+// by lists of members. For more info refer to the ZK documentation.
+//
+// An optional version allows for conditional reconfigurations, -1 ignores the condition.
+//
+// Returns the new configuration znode stat.
 func (c *Conn) IncrementalReconfig(joining, leaving []string, version int64) (*Stat, error) {
 	// TODO: validate the shape of the member string to give early feedback.
 	request := &reconfigRequest{
@@ -1257,9 +1260,12 @@ func (c *Conn) IncrementalReconfig(joining, leaving []string, version int64) (*S
 	return c.internalReconfig(request)
 }
 
-// Reconfig is the non-incremental update functionality for Zookeeper where the list preovided
-// is the entire new member list.
-// the optional version allows for conditional reconfigurations, -1 ignores the condition.
+// Reconfig is the non-incremental update functionality for Zookeeper where the list provided
+// is the entire new member list. For more info refer to the ZK documentation.
+//
+// An optional version allows for conditional reconfigurations, -1 ignores the condition.
+//
+// Returns the new configuration znode stat.
 func (c *Conn) Reconfig(members []string, version int64) (*Stat, error) {
 	request := &reconfigRequest{
 		NewMembers:  []byte(strings.Join(members, ",")),

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -10,6 +10,7 @@ Possible watcher events:
 */
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
@@ -102,9 +103,10 @@ type Conn struct {
 	reconnectLatch   chan struct{}
 	setWatchLimit    int
 	setWatchCallback func([]*setWatchesRequest)
+
 	// Debug (for recurring re-auth hang)
 	debugCloseRecvLoop bool
-	debugReauthDone    chan struct{}
+	resendZkAuthFn     func(context.Context, *Conn) error
 
 	logger  Logger
 	logInfo bool // true if information messages are logged; false if only errors are logged
@@ -207,6 +209,7 @@ func Connect(servers []string, sessionTimeout time.Duration, options ...connOpti
 		logger:         DefaultLogger,
 		logInfo:        true, // default is true for backwards compatability
 		buf:            make([]byte, bufferSize),
+		resendZkAuthFn: resendZkAuth,
 	}
 
 	// Set provided options.
@@ -219,9 +222,11 @@ func Connect(servers []string, sessionTimeout time.Duration, options ...connOpti
 	}
 
 	conn.setTimeouts(int32(sessionTimeout / time.Millisecond))
+	// TODO: Connect should provide a way to specify a context for the connection
+	ctx := context.Background()
 
 	go func() {
-		conn.loop()
+		conn.loop(ctx)
 		conn.flushRequests(ErrClosing)
 		conn.invalidateWatches(ErrClosing)
 		close(conn.eventChan)
@@ -310,6 +315,8 @@ func WithMaxConnBufferSize(maxBufferSize int) connOption {
 	}
 }
 
+// Close will submit a close request with ZK and signal the connection to stop
+// sending and receiving packets.
 func (c *Conn) Close() {
 	c.shouldQuitOnce.Do(func() {
 		close(c.shouldQuit)
@@ -367,7 +374,9 @@ func (c *Conn) connect() error {
 		c.serverMu.Lock()
 		c.server, retryStart = c.hostProvider.Next()
 		c.serverMu.Unlock()
+
 		c.setState(StateConnecting)
+
 		if retryStart {
 			c.flushUnsentRequests(ErrNoServer)
 			select {
@@ -385,70 +394,12 @@ func (c *Conn) connect() error {
 			c.conn = zkConn
 			c.setState(StateConnected)
 			if c.logInfo {
-				c.logger.Printf("Connected to %s", c.Server())
+				c.logger.Printf("connected to %s", c.Server())
 			}
 			return nil
 		}
 
-		c.logger.Printf("Failed to connect to %s: %+v", c.Server(), err)
-	}
-}
-
-func (c *Conn) resendZkAuth(reauthReadyChan chan struct{}) {
-	shouldCancel := func() bool {
-		select {
-		case <-c.shouldQuit:
-			return true
-		case <-c.closeChan:
-			return true
-		default:
-			return false
-		}
-	}
-
-	c.credsMu.Lock()
-	defer c.credsMu.Unlock()
-
-	defer close(reauthReadyChan)
-
-	if c.logInfo {
-		c.logger.Printf("re-submitting `%d` credentials after reconnect", len(c.creds))
-	}
-
-	for _, cred := range c.creds {
-		if shouldCancel() {
-			return
-		}
-		resChan, err := c.sendRequest(
-			opSetAuth,
-			&setAuthRequest{Type: 0,
-				Scheme: cred.scheme,
-				Auth:   cred.auth,
-			},
-			&setAuthResponse{},
-			nil)
-
-		if err != nil {
-			c.logger.Printf("call to sendRequest failed during credential resubmit: %s", err)
-			// FIXME(prozlach): lets ignore errors for now
-			continue
-		}
-
-		var res response
-		select {
-		case res = <-resChan:
-		case <-c.closeChan:
-			c.logger.Printf("recv closed, cancel re-submitting credentials")
-			return
-		case <-c.shouldQuit:
-			c.logger.Printf("should quit, cancel re-submitting credentials")
-			return
-		}
-		if res.err != nil {
-			c.logger.Printf("credential re-submit failed: %s", res.err)
-			// FIXME(prozlach): lets ignore errors for now
-			continue
-		}
+		c.logger.Printf("failed to connect to %s: %v", c.Server(), err)
 	}
 }
 
@@ -477,7 +428,7 @@ func (c *Conn) sendRequest(
 	return rq.recvChan, nil
 }
 
-func (c *Conn) loop() {
+func (c *Conn) loop(ctx context.Context) {
 	for {
 		if err := c.connect(); err != nil {
 			// c.Close() was called
@@ -498,25 +449,29 @@ func (c *Conn) loop() {
 			}
 			c.hostProvider.Connected()        // mark success
 			c.closeChan = make(chan struct{}) // channel to tell send loop stop
-			reauthChan := make(chan struct{}) // channel to tell send loop that authdata has been resubmitted
 
 			var wg sync.WaitGroup
+
 			wg.Add(1)
 			go func() {
-				<-reauthChan
-				if c.debugCloseRecvLoop {
-					close(c.debugReauthDone)
+				defer c.conn.Close() // causes recv loop to EOF/exit
+				defer wg.Done()
+
+				if err := c.resendZkAuthFn(ctx, c); err != nil {
+					c.logger.Printf("error in resending auth creds: %v", err)
+					return
 				}
-				err := c.sendLoop()
-				if err != nil || c.logInfo {
-					c.logger.Printf("send loop terminated: err=%v", err)
+
+				if err := c.sendLoop(); err != nil || c.logInfo {
+					c.logger.Printf("send loop terminated: %v", err)
 				}
-				c.conn.Close() // causes recv loop to EOF/exit
-				wg.Done()
 			}()
 
 			wg.Add(1)
 			go func() {
+				defer close(c.closeChan) // tell send loop to exit
+				defer wg.Done()
+
 				var err error
 				if c.debugCloseRecvLoop {
 					err = errors.New("DEBUG: close recv loop")
@@ -524,16 +479,12 @@ func (c *Conn) loop() {
 					err = c.recvLoop(c.conn)
 				}
 				if err != io.EOF || c.logInfo {
-					c.logger.Printf("recv loop terminated: err=%v", err)
+					c.logger.Printf("recv loop terminated: %v", err)
 				}
 				if err == nil {
 					panic("zk: recvLoop should never return nil error")
 				}
-				close(c.closeChan) // tell send loop to exit
-				wg.Done()
 			}()
-
-			c.resendZkAuth(reauthChan)
 
 			c.sendSetWatches()
 			wg.Wait()
@@ -674,7 +625,7 @@ func (c *Conn) sendSetWatches() {
 		for _, req := range reqs {
 			_, err := c.request(opSetWatches, req, res, nil)
 			if err != nil {
-				c.logger.Printf("Failed to set previous watches: %s", err.Error())
+				c.logger.Printf("Failed to set previous watches: %v", err)
 				break
 			}
 		}
@@ -1286,4 +1237,63 @@ func (c *Conn) Server() string {
 	c.serverMu.Lock()
 	defer c.serverMu.Unlock()
 	return c.server
+}
+
+func resendZkAuth(ctx context.Context, c *Conn) error {
+	shouldCancel := func() bool {
+		select {
+		case <-c.shouldQuit:
+			return true
+		case <-c.closeChan:
+			return true
+		default:
+			return false
+		}
+	}
+
+	c.credsMu.Lock()
+	defer c.credsMu.Unlock()
+
+	if c.logInfo {
+		c.logger.Printf("re-submitting `%d` credentials after reconnect", len(c.creds))
+	}
+
+	for _, cred := range c.creds {
+		// return early befor attempting to send request.
+		if shouldCancel() {
+			return nil
+		}
+		// do not use the public API for auth since it depends on the send/recv loops
+		// that are waiting for this to return
+		resChan, err := c.sendRequest(
+			opSetAuth,
+			&setAuthRequest{Type: 0,
+				Scheme: cred.scheme,
+				Auth:   cred.auth,
+			},
+			&setAuthResponse{},
+			nil, /* recvFunc*/
+		)
+		if err != nil {
+			return fmt.Errorf("failed to send auth request: %v", err)
+		}
+
+		var res response
+		select {
+		case res = <-resChan:
+		case <-c.closeChan:
+			c.logger.Printf("recv closed, cancel re-submitting credentials")
+			return nil
+		case <-c.shouldQuit:
+			c.logger.Printf("should quit, cancel re-submitting credentials")
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		if res.err != nil {
+			return fmt.Errorf("failed conneciton setAuth request: %v", res.err)
+		}
+	}
+
+	return nil
 }

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -222,8 +222,7 @@ func Connect(servers []string, sessionTimeout time.Duration, options ...connOpti
 	}
 
 	conn.setTimeouts(int32(sessionTimeout / time.Millisecond))
-	// TODO: this context should become to control the goroutines
-	// and connection itself, like use net.DialContext.
+	// TODO: This context should be passed in by the caller to be the connection lifecycle context.
 	ctx := context.Background()
 
 	go func() {

--- a/zk/conn_test.go
+++ b/zk/conn_test.go
@@ -9,22 +9,7 @@ import (
 )
 
 func TestRecurringReAuthHang(t *testing.T) {
-	t.Skip("Race condition in test")
-
-	sessionTimeout := 2 * time.Second
-
-	finish := make(chan struct{})
-	defer close(finish)
-	go func() {
-		select {
-		case <-finish:
-			return
-		case <-time.After(5 * sessionTimeout):
-			panic("expected not hang")
-		}
-	}()
-
-	zkC, err := StartTestCluster(t, 2, ioutil.Discard, ioutil.Discard)
+	zkC, err := StartTestCluster(t, 3, ioutil.Discard, ioutil.Discard)
 	if err != nil {
 		panic(err)
 	}

--- a/zk/server_help.go
+++ b/zk/server_help.go
@@ -36,7 +36,7 @@ type TestCluster struct {
 
 func StartTestCluster(t *testing.T, size int, stdout, stderr io.Writer) (*TestCluster, error) {
 	if testing.Short() {
-		t.Skip("ZK clsuter tests skipped in short case.")
+		t.Skip("ZK cluster tests skipped in short case.")
 	}
 	tmpPath, err := ioutil.TempDir("", "gozk")
 	requireNoError(t, err, "failed to create tmp dir for test server setup")

--- a/zk/server_java.go
+++ b/zk/server_java.go
@@ -65,8 +65,8 @@ func (srv *server) Start() error {
 	srv.cmd = exec.CommandContext(ctx, srv.cmdString, srv.cmdArgs...)
 	srv.cmd.Stdout = srv.stdout
 	srv.cmd.Stderr = srv.stderr
-
 	srv.cmd.Env = srv.cmdEnv
+
 	return srv.cmd.Start()
 }
 

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -320,6 +320,7 @@ func TestIfAuthdataSurvivesReconnect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ts.Stop()
 
 	zk, _, err := ts.ConnectAll()
 	if err != nil {

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -241,7 +241,37 @@ func TestReconfig(t *testing.T) {
 
 	_, err = zk.Reconfig(s, -1)
 	requireNoError(t, err, "failed to reconfig cluster")
+}
 
+func TestOpsAfterCloseDontDeadlock(t *testing.T) {
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+	zk, _, err := ts.ConnectAll()
+	if err != nil {
+		t.Fatalf("Connect returned error: %+v", err)
+	}
+	zk.Close()
+
+	path := "/gozk-test"
+
+	ch := make(chan struct{})
+	go func() {
+		defer close(ch)
+		for range make([]struct{}, 30) {
+			if _, err := zk.Create(path, []byte{1, 2, 3, 4}, 0, WorldACL(PermAll)); err == nil {
+				t.Fatal("Create did not return error")
+			}
+		}
+	}()
+	select {
+	case <-ch:
+		// expected
+	case <-time.After(10 * time.Second):
+		t.Fatal("ZK connection deadlocked when executing ops after a Close operation")
+	}
 }
 
 func TestMulti(t *testing.T) {
@@ -815,6 +845,16 @@ func TestRequestFail(t *testing.T) {
 	case <-time.After(time.Second * 2):
 		t.Fatal("Get hung when connection could not be made")
 	}
+}
+
+func TestIdempotentClose(t *testing.T) {
+	zk, _, err := Connect([]string{"127.0.0.1:32444"}, time.Second*15)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// multiple calls to Close() should not panic
+	zk.Close()
+	zk.Close()
 }
 
 func TestSlowServer(t *testing.T) {


### PR DESCRIPTION
While merging in the mesos changes was fine upon review and testing i added an err nil check for connection logic as well as remove some of the debugging parameters since we do not want this in production code. 

Later improvements on the connection can be done to allow better unit testing. I also added comments around futures regarding testing since this repo is doing integration tests that are heavy and should be isolated to only running on demand. Unit tests should remain fast and reliable with no external dependencies.

Update: in more testing the debug of reauth and the test around it were flaky. This fixes the reauth function to be a function field on the connection for better testing. the signal channel can now be isolated to testing only and production will not have this added complication. 